### PR TITLE
Github Workflow : Notify Contributors When Pull Requests Are Merged

### DIFF
--- a/.github/workflows/auto-comment-on-pr-merge.yml
+++ b/.github/workflows/auto-comment-on-pr-merge.yml
@@ -1,0 +1,37 @@
+name: Auto Comment on PR Merge
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  comment:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+     - name: Add Comment to Merged PR
+       run: |
+        COMMENT=$(cat <<EOF
+        {
+          "body": "🎉 Your pull request has been successfully merged! 🎉 Thank you for your contribution to our project. Your efforts are greatly appreciated. Keep up the fantastic work! 🚀"
+        }
+        EOF
+        )
+        RESPONSE=$(curl -s -o response.json -w "%{http_code}" \
+          -X POST \
+          -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Accept: application/vnd.github.v3+json" \
+          https://api.github.com/repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments \
+          -d "$COMMENT")
+        cat response.json
+        if [ "$RESPONSE" -ne 201 ]; then
+          echo "Failed to add comment"
+          exit 1
+        fi
+       env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Notify Contributors When Pull Requests Are Merged
fixed #77 
### Issue Description
**Background:**
Currently, when a pull request (PR) is merged, contributors are not notified about the status of their contributions. It’s important to acknowledge their efforts and keep them informed to foster a positive and collaborative environment.

**Benefits:**
- Enhances contributor engagement.
- Acknowledges their work, which can encourage future contributions.
- Improves communication within the project.

