### PR TITLE
Add Face Registration Endpoint

### DIFF
--- a/register_face.py
+++ b/register_face.py
@@ -1,26 +1,25 @@
-from fastapi import FastAPI, File, UploadFile, Form
 from deepface import DeepFace
-from pymongo import MongoClient
+from fastapi import FastAPI, File, Form, UploadFile
 from pydantic import BaseModel
+from pymongo import MongoClient
 
 app = FastAPI()
-client = MongoClient('mongodb://localhost:27017/')
-db = client['face_recognition']
-users_collection = db['users']
+client = MongoClient("mongodb://localhost:27017/")
+db = client["face_recognition"]
+users_collection = db["users"]
+
 
 @app.post("/register/")
 async def register_face(image: UploadFile = File(...), name: str = Form(...)):
     # Perform face recognition and get face embedding
     try:
-        face_embedding = DeepFace.represent(img_path=image.file, model_name='Facenet')
-        
+        face_embedding = DeepFace.represent(
+            img_path=image.file, model_name="Facenet")
+
         # Store face embedding and metadata in MongoDB
-        user_data = {
-            "name": name,
-            "face_embedding": face_embedding
-        }
+        user_data = {"name": name, "face_embedding": face_embedding}
         users_collection.insert_one(user_data)
-        
+
         return {"message": "Face registered successfully"}
     except Exception as e:
         return {"error": str(e)}, 500

--- a/register_face.py
+++ b/register_face.py
@@ -1,0 +1,26 @@
+from fastapi import FastAPI, File, UploadFile, Form
+from deepface import DeepFace
+from pymongo import MongoClient
+from pydantic import BaseModel
+
+app = FastAPI()
+client = MongoClient('mongodb://localhost:27017/')
+db = client['face_recognition']
+users_collection = db['users']
+
+@app.post("/register/")
+async def register_face(image: UploadFile = File(...), name: str = Form(...)):
+    # Perform face recognition and get face embedding
+    try:
+        face_embedding = DeepFace.represent(img_path=image.file, model_name='Facenet')
+        
+        # Store face embedding and metadata in MongoDB
+        user_data = {
+            "name": name,
+            "face_embedding": face_embedding
+        }
+        users_collection.insert_one(user_data)
+        
+        return {"message": "Face registered successfully"}
+    except Exception as e:
+        return {"error": str(e)}, 500


### PR DESCRIPTION
### Description
@Devasy23  This PR introduces a new **Face Registration** feature to the FaceRec project using FastAPI and DeepFace. It provides an endpoint that allows users to register their face, along with associated metadata (such as name), into the MongoDB database. 

### Key Features:
- **FastAPI Endpoint**: `/register/` accepts a form field (`name`) and an image file (`image`) for face registration.
- **DeepFace Integration**: Extracts face embeddings using the `Facenet` model from DeepFace.
- **MongoDB Storage**: Stores the face embeddings and metadata in the `face_recognition` database.
- **Error Handling**: Includes error handling for failed face registration or database operations.

### Usage Example:
To register a new face, send a POST request with the following form data:
```bash
POST /register/
Content-Type: multipart/form-data
Body:
  - image: (upload file)
  - name: "User's Name"
